### PR TITLE
Moved settimeout before zabbix.connect()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name = "zbxsend",
-    version = "0.1.6.2",
+    version = "0.1.6.3",
     author = "Sergey Kirillov",
     author_email = "sergey.kirillov@gmail.com",
     description = ("Module used to send metrics to Zabbix."),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name = "zbxsend",
-    version = "0.1.6.2",
+    version = "0.1.6",
     author = "Sergey Kirillov",
     author_email = "sergey.kirillov@gmail.com",
     description = ("Module used to send metrics to Zabbix."),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name = "zbxsend",
-    version = "0.1.6",
+    version = "0.1.6.2",
     author = "Sergey Kirillov",
     author_email = "sergey.kirillov@gmail.com",
     description = ("Module used to send metrics to Zabbix."),

--- a/zbxsend.py
+++ b/zbxsend.py
@@ -27,7 +27,7 @@ def send_to_zabbix(metrics, zabbix_host='127.0.0.1', zabbix_port=10051, timeout=
     # Zabbix has very fragile JSON parser, and we cannot use json to dump whole packet
     metrics_data = []
     for m in metrics:
-        clock = m.clock or time.time()
+        clock = int(m.clock or time.time())
         metrics_data.append(('\t\t{\n'
                              '\t\t\t"host":%s,\n'
                              '\t\t\t"key":%s,\n'

--- a/zbxsend.py
+++ b/zbxsend.py
@@ -21,8 +21,8 @@ class Metric(object):
         return 'Metric(%r, %r, %r, %r)' % (self.host, self.key, self.value, self.clock)
 
 def send_to_zabbix(metrics, zabbix_host='127.0.0.1', zabbix_port=10051, timeout=15):
-    """Send set of metrics to Zabbix server.""" 
-    
+    """Send set of metrics to Zabbix server."""
+
     j = json.dumps
     # Zabbix has very fragile JSON parser, and we cannot use json to dump whole packet
     metrics_data = []
@@ -37,13 +37,13 @@ def send_to_zabbix(metrics, zabbix_host='127.0.0.1', zabbix_port=10051, timeout=
            '\t"request":"sender data",\n'
            '\t"data":[\n%s]\n'
            '}') % (',\n'.join(metrics_data))
-    
+
     data_len = struct.pack('<Q', len(json_data))
     packet = 'ZBXD\1' + data_len + json_data
     try:
         zabbix = socket.socket()
-        zabbix.connect((zabbix_host, zabbix_port))
         zabbix.settimeout(timeout)
+        zabbix.connect((zabbix_host, zabbix_port))
         # send metrics to zabbix
         zabbix.sendall(packet)
         # get response header from zabbix
@@ -72,7 +72,7 @@ def send_to_zabbix(metrics, zabbix_host='127.0.0.1', zabbix_port=10051, timeout=
 
 
 
-logger = logging.getLogger('zbxsender') 
+logger = logging.getLogger('zbxsender')
 
 def _recv_all(sock, count):
     buf = ''
@@ -83,7 +83,7 @@ def _recv_all(sock, count):
         buf += chunk
     return buf
 
-    
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     send_to_zabbix([Metric('localhost', 'bucks_earned', 99999)], 'localhost', 10051)

--- a/zbxsend.py
+++ b/zbxsend.py
@@ -41,7 +41,11 @@ def send_to_zabbix(metrics, zabbix_host='127.0.0.1', zabbix_port=10051, timeout=
     data_len = struct.pack('<Q', len(json_data))
     packet = 'ZBXD\1' + data_len + json_data
     try:
-        zabbix = socket.socket()
+        addrs = socket.getaddrinfo(zabbix_host, zabbix_port)
+        if len(addrs) > 0 and addrs[0][0] == socket.AF_INET6:
+            zabbix = socket.socket(socket.AF_INET6)
+        else:
+            zabbix = socket.socket(socket.AF_INET)
         zabbix.settimeout(timeout)
         zabbix.connect((zabbix_host, zabbix_port))
         # send metrics to zabbix


### PR DESCRIPTION
The zabbix.connect() socket call does not currently use the timeout as set in the send_to_zabbix function. This patch moves the zabbix.settimeout() before that to fix this.
